### PR TITLE
Patch/coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,7 @@
 [run]
-source=behave_webdriver
+branch = True
+source = behave_webdriver
+
+[report]
+exclude_lines =
+    raise NotImplementedError

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install: # Install ChromeDriver.
   - rm ./chromedriver_linux64.zip
   - chmod +x ./chromedriver
   - pip install -r ./requirements.txt
-  - pip install codecov
+  - pip install coveralls
 
 script:
   - cd tests/demo-app
@@ -24,4 +24,4 @@ script:
 
 
 after_success:
-  - codecov -X gcov
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ behave-webdriver is a step library intended to allow users to easily run [seleni
 Inspired by the webdriverio [cucumber-boilerplate](https://github.com/webdriverio/cucumber-boilerplate) project.
 
 [![Build Status](https://travis-ci.org/spyoungtech/behave-webdriver.svg?branch=master)](https://travis-ci.org/spyoungtech/behave-webdriver)
-[![codecov](https://codecov.io/gh/spyoungtech/behave-webdriver/branch/master/graph/badge.svg)](https://codecov.io/gh/spyoungtech/behave-webdriver)
+[![Coverage Status](https://coveralls.io/repos/github/spyoungtech/behave-webdriver/badge.svg)](https://coveralls.io/github/spyoungtech/behave-webdriver)
 
 Be sure to check out the full  [behave-webdriver documentation](http://behave-webdriver.readthedocs.io/en/latest/) 
 


### PR DESCRIPTION
Use coveralls instead of codecov. Add exclusion for `raise NotImplementedError`

For whatever reason, codecov doesn't want to report on the `__init__.py` file in the package root. see codecov/codecov-python#136 

So we'll use coveralls for now.