### PR TITLE
Patch/cleanup 0.1.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,8 +84,23 @@ options to run headless. This is useful, for example in headless testing environ
    def before_all(context):
        context.behave_driver = behave_webdriver.Chrome.headless()
 
-In the future, behave-webdriver will provide `fixtures`_ for the setup and teardown of webdrivers.
-See the behave tutorial for more information about `environment controls`_ .
+
+Using a fixture
+^^^^^^^^^^^^^^^
+
+*New in 0.1.1*
+
+You may also find it convenient to use a fixture to setup your driver as well. For example, to use our fixture with Firefox
+
+.. code-block:: python
+
+    from behave_webdriver.fixtures import fixture_browser
+    def before_all(context):
+        use_fixture(fixture_browser, webdriver='Firefox')
+
+This will also ensure that the browser is torn down at the corresponding `cleanup point`_.
+
+.. _cleanup point: http://behave.readthedocs.io/en/stable/fixtures.html#fixture-cleanup-points
 
 Writing the feature file
 ------------------------
@@ -337,24 +352,24 @@ Then Steps ✔️
 Acknowledgements ❤️
 ===================
 
-Special thanks to the authors of the `webdriverio/cucumber-boilerplate`_ project
+Special thanks to the authors and contributors of the `webdriverio/cucumber-boilerplate`_ project
 
-Special thanks to the authors of `behave`_
+Special thanks to the authors and contributors of `behave`_
 
 
 
 
 .. _selenium-requests: https://github.com/cryzed/Selenium-Requests
 
-.. _environment controls: http://behave.readthedocs.io/en/latest/tutorial.html#environmental-controls
+.. _environment controls: http://behave.readthedocs.io/en/stable/tutorial.html#environmental-controls
 
-.. _fixtures: http://behave.readthedocs.io/en/latest/fixtures.html
+.. _fixtures: http://behave.readthedocs.io/en/stable/fixtures.html
 
-.. _step implementations: http://behave.readthedocs.io/en/latest/tutorial.html#python-step-implementations
+.. _step implementations: http://behave.readthedocs.io/en/stable/tutorial.html#python-step-implementations
 
 .. _driver installation notes: http://selenium-python.readthedocs.io/installation.html#drivers
 
-.. _behave-webdriver documentation: http://behave-webdriver.readthedocs.io/en/latest/
+.. _behave-webdriver documentation: http://behave-webdriver.readthedocs.io/en/stable/
 
 .. _selenium: https://github.com/SeleniumHQ/selenium
 
@@ -364,8 +379,8 @@ Special thanks to the authors of `behave`_
 
 
 
-.. |docs| image:: https://readthedocs.org/projects/behave-webdriver/badge/?version=latest
-    :target: http://behave-webdriver.readthedocs.io/en/latest/
+.. |docs| image:: https://readthedocs.org/projects/behave-webdriver/badge/?version=stable
+    :target: http://behave-webdriver.readthedocs.io/en/stable/
 
 .. |status| image:: https://travis-ci.org/spyoungtech/behave-webdriver.svg?branch=master
     :target: https://travis-ci.org/spyoungtech/behave-webdriver

--- a/behave_webdriver/__init__.py
+++ b/behave_webdriver/__init__.py
@@ -11,10 +11,6 @@ __all__ = [
     'Remote',
     'from_env',
     'from_string',
-    'fixture_browser',
-    'before_all_factory',
-    'before_feature_factory',
-    'before_scenario_factory',
 ]
 from behave_webdriver.driver import (Chrome,
                                      Firefox,
@@ -28,7 +24,3 @@ from behave_webdriver.driver import (Chrome,
                                      Remote)
 from behave_webdriver.utils import (from_env,
                                     from_string)
-from behave_webdriver.fixtures import (fixture_browser,
-                                       before_all_factory,
-                                       before_feature_factory,
-                                       before_scenario_factory)

--- a/behave_webdriver/driver.py
+++ b/behave_webdriver/driver.py
@@ -692,14 +692,12 @@ class Edge(BehaveDriverMixin, webdriver.Edge):
     """
     Edge driver class. Alternate constructors and browser-specific logic is implemented here.
     """
-    pass
 
 
 class Opera(BehaveDriverMixin, webdriver.Opera):
     """
     Opera driver class. Alternate constructors and browser-specific logic is implemented here.
     """
-    pass
 
 
 class Safari(BehaveDriverMixin, webdriver.Safari):
@@ -713,19 +711,16 @@ class BlackBerry(BehaveDriverMixin, webdriver.BlackBerry):
     """
     BlackBerry driver class. Alternate constructors and browser-specific logic is implemented here.
     """
-    pass
 
 
 class Android(BehaveDriverMixin, webdriver.Android):
     """
     Android driver class. Alternate constructors and browser-specific logic is implemented here.
     """
-    pass
 
 
 class Remote(BehaveDriverMixin, webdriver.Remote):
     """
     Remote driver class. Alternate constructors and browser-specific logic is implemented here.
     """
-    pass
 

--- a/behave_webdriver/fixtures.py
+++ b/behave_webdriver/fixtures.py
@@ -1,169 +1,114 @@
 """
 Provides fixtures to initialize the web driver.
 """
+
 from behave import fixture, use_fixture
 from behave_webdriver.utils import _from_string, _from_env
 from behave_webdriver.driver import BehaveDriverMixin
 
 
-_env_webdriver_name = 'env'
-
-
 @fixture
-def fixture_browser(ctx, *args, **kwargs):
+def fixture_browser(context, *args, **kwargs):
     """
-    Provide a web driver browser as `ctx.behave_driver`.
-    
-    Can raise ValueError in case of bad parameters.
+    webdriver setup fixture for behave context; sets ``context.behave_driver``.
 
     Will destroy the driver at the end of this fixture usage.
 
-    :param webdriver_name: the name of the webdriver.
-                           Special 'env' name is to tell to get the name from `BEHAVE_WEBDRIVER` environment variable.
-                           Default to 'env'.
-    :param webdriver_class: the class to use instead of using a name. The class must both inherit from
-                            - `behave_webdriver.driver.BehaveDriverMixin`
-                            - a driver from `selenium.webdriver`
-                            or be a subclass of a driver from `behave_webdriver.driver`.
-                            Default to None.
-    :param webdriver_args: function that takes a context and a `webdriver_class` and returns a tuple of
-                           - list of positional arguments
-                           - dictionary of keyword arguments
-                            Default to None.
-    :param default_driver: used for `from_env` method in `webdriver_name` is 'env'.
-                           Default to None.
-    :param args: arguments that will be passed as is to the driver constructor.
-                 They will be added to those from `webdriver_args`.
-    :param kwargs: keywords arguments that will be passed as is to the driver constructor.
-                   They will be added to those from `webdriver_args`.
-    :return: web driver initialized
+    :param webdriver: the webdriver to use -- can be a string (e.g. ``"Chrome"``) or a webdriver class. If omitted, will attempt to use the BEHAVE_WEBDRIVER environment variable
 
-    Use it like this:
+    :param default_driver: a fallback driver if webdriver keyword is not provided AND the BEHAVE_WEBDRIVER environment variable is not set. Defaults to 'Chrome.headless'
+
+    :param args: arguments that will be passed as is to the webdriver.
+    :param kwargs: keywords arguments that will be passed as is to the webdriver.
+
+    Basic usage:
 
     >>> from behave import use_fixture
-    >>> from behave_webdriver import fixture_browser
-    >>> def before_all(ctx):
-    ...     use_fixture(fixture_browser, ctx)
+    >>> from behave_webdriver.fixtures import fixture_browser
+    >>> def before_all(context):
+    ...     use_fixture(fixture_browser, context, webdriver='firefox')
 
-    It will try to instantiate a `Chrome` driver (the default).
-
-    You can specify it in a environment variable:
-
-    >>> from os import environ
-    >>> from behave import use_fixture
-    >>> from behave_webdriver import fixture_browser
-    >>> def before_all(ctx):
-    ...     assert environ['BEHAVE_WEBDRIVER'] == 'firefox'
-    ...     use_fixture(fixture_browser, ctx)
-
-    It will try to instantiate a `Firefox` driver.
-
-    You could also provide the name:
+    You may also provide webdriver class. Just be sure it inherits (or otherwise has method from) BehaveDriverMixin
 
     >>> from behave import use_fixture
-    >>> from behave_webdriver import fixture_browser
-    >>> def before_all(ctx):
-    ...     use_fixture(fixture_browser, ctx, webdriver_name='firefox')
-
-    You could direcly provide webdriver class:
-
-    >>> from behave import use_fixture
-    >>> from behave_webdriver import fixture_browser
+    >>> from behave_webdriver.fixtures import fixture_browser
     >>> from behave_webdriver.driver import BehaveDriverMixin
-    >>> from selenium.driver import Firefox
+    >>> from selenium.webdriver import Firefox
     >>> class FirefoxDriver(BehaveDriverMixin, Firefox):
     ...     pass
-    >>> def before_all(ctx):
-    ...     use_fixture(fixture_browser, ctx, webdriver_class=FirefoxDriver)
+    >>> def before_all(context):
+    ...     use_fixture(fixture_browser, context, webdriver=FirefoxDriver)
 
-    You could pass constructor parameters to the webdriver:
+    positional arguments and additional keyword arguments are passed to the webdriver init:
 
     >>> from behave import use_fixture
-    >>> from behave_webdriver import fixture_browser
+    >>> from behave_webdriver.fixtures import fixture_browser
     >>> from behave_webdriver.driver import ChromeOptions
-    >>> def before_all(ctx):
+    >>> def before_all(context):
     ...     options = ChromeOptions()
     ...     options.add_argument('--ignore-gpu-blacklist')
-    ...     use_fixture(fixture_browser, ctx, webdriver_name='chrome', options=options)
+    ...     use_fixture(fixture_browser, context, webdriver='chrome', options=options)
 
-    You could also use a function to pass constructor parameters to the webdriver:
+    If the ``webdriver`` keyword is omitted, will attampt to get the driver from BEHAVE_WEBDRIVER or will use headless chrome as a final fallback if environment is not set and there is no ``default_driver`` specified
 
     >>> from behave import use_fixture
-    >>> from behave_webdriver import fixture_browser
-    >>> from behave_webdriver.driver import Chrome, ChromeOptions
-    >>> def get_driver_args(ctx, driver):
-    ...     if driver == Chrome:
-    ...         options = ChromeOptions()
-    ...         options.add_argument('--ignore-gpu-blacklist')
-    ...         return ([], {'options': options}
-    ...     else:
-    ...         return ([], {})
-    >>> def before_all(ctx):
-    ...     use_fixture(fixture_browser, ctx, webdriver_args=get_driver_args)
+    >>> from behave_webdriver.fixtures import fixture_browser
+    >>> def before_all(context):
+    ...     #  try to use driver from BEHAVE_WEBDRIVER environment variable; use firefox as a fallback when env not set
+    ...     use_fixture(fixture_browser, context, default_driver='firefox')
+
     """
-    webdriver_name = kwargs.pop('webdriver_name', _env_webdriver_name)
-    webdriver_class = kwargs.pop('webdriver_class', None)
-    webdriver_args = kwargs.pop('webdriver_args', None)
-    if webdriver_class is not None:
-        if BehaveDriverMixin not in webdriver_class.mro():
-            raise ValueError('The driver "{}" does not inherit from BehaveDriverMixin.'.format(webdriver_class.__name__))
-    elif webdriver_name == _env_webdriver_name:
-        if 'default_driver' in kwargs:
-            default_driver = kwargs.pop('default_driver')
-        else:
-            default_driver = None
-        # can raise a ValueError
-        webdriver_class = _from_env(default_driver=default_driver)
-    else:
-        # can raise a ValueError
-        webdriver_class = _from_string(webdriver_name)
-    if callable(webdriver_args):
-        wd_args, wd_kwargs = webdriver_args(ctx, webdriver_class)
-        args = tuple(wd_args) + tuple(args)
-        kwargs = dict(list(wd_kwargs.items()) + list(kwargs.items()))
-    ctx.behave_driver = webdriver_class(*args, **kwargs)
-    yield ctx.behave_driver
-    ctx.behave_driver.quit()
-    del ctx.behave_driver
+
+    webdriver = kwargs.pop('webdriver', None)
+    default_driver = kwargs.pop('default_driver', 'Chrome.headless')
+    if isinstance(webdriver, str):
+        webdriver = _from_string(webdriver)
+    if webdriver is None:
+        webdriver = _from_env(default_driver=default_driver)
+
+    context.behave_driver = webdriver(*args, **kwargs)
+    yield context.behave_driver
+    context.behave_driver.quit()
+    del context.behave_driver
 
 
 def before_all_factory(*args, **kwargs):
     """
-    Create and return a `before_all` function that use the `fixture_browser` fixture with the corresponding arguments
-    :param args: positional arguments of `fixture_browser` function
-    :param kwargs: keywords arguments of `fixture_browser` function, including `webdriver_name`, `webdriver_class` and `webdriver_args` arguments
+    Create and return a ``before_all`` function that use the ``fixture_browser`` fixture with the corresponding arguments
+    :param args: positional arguments of ``fixture_browser``
+    :param kwargs: keywords arguments of ``fixture_browser``
 
-    >>> from behave_webdriver import before_all_factory
-    >>> before_all = before_all_factory(webdriver_name='firefox')
+    >>> from behave_webdriver.fixtures import before_all_factory
+    >>> before_all = before_all_factory(webdriver='firefox')
     """
-    def before_all(ctx):
-        use_fixture(fixture_browser, ctx, *args, **kwargs)
+    def before_all(context):
+        use_fixture(fixture_browser, context, *args, **kwargs)
     return before_all
 
 
 def before_feature_factory(*args, **kwargs):
     """
-    Create and return a `before_feature` function that use the `fixture_browser` fixture with the corresponding arguments
-    :param args: positional arguments of `fixture_browser` function
-    :param kwargs: keywords arguments of `fixture_browser` function, including `webdriver_name`, `webdriver_class` and `webdriver_args` arguments
+    Create and return a ``before_feature` function that use the ``fixture_browser`` fixture with the corresponding arguments
+    :param args: positional arguments of ``fixture_browser``
+    :param kwargs: keywords arguments of ``fixture_browser``
 
-    >>> from behave_webdriver import before_feature_factory
-    >>> before_feature = before_feature_factory(webdriver_name='firefox')
+    >>> from behave_webdriver.fixtures import before_feature_factory
+    >>> before_feature = before_feature_factory(webdriver='firefox')
     """
-    def before_feature(ctx, feature):
-        use_fixture(fixture_browser, ctx, *args, **kwargs)
+    def before_feature(context, feature):
+        use_fixture(fixture_browser, context, *args, **kwargs)
     return before_feature
 
 
 def before_scenario_factory(*args, **kwargs):
     """
-    Create and return a `before_scenario` function that use the `fixture_browser` fixture with the corresponding arguments
-    :param args: positional arguments of `fixture_browser` function
-    :param kwargs: keywords arguments of `fixture_browser` function, including `webdriver_name`, `webdriver_class` and `webdriver_args` arguments
+    Create and return a ``before_scenario`` function that use the ``fixture_browser`` fixture with the corresponding arguments
+    :param args: positional arguments of ``fixture_browser``
+    :param kwargs: keywords arguments of ``fixture_browser``
 
-    >>> from behave_webdriver import before_scenario_factory
-    >>> before_scenario = before_scenario_factory(webdriver_name='firefox')
+    >>> from behave_webdriver.fixtures import before_scenario_factory
+    >>> before_scenario = before_scenario_factory(webdriver='firefox')
     """
-    def before_scenario(ctx, scenario):
-        use_fixture(fixture_browser, ctx, *args, **kwargs)
+    def before_scenario(context, scenario):
+        use_fixture(fixture_browser, context, *args, **kwargs)
     return before_scenario

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -28,22 +28,22 @@ mixin as well as the respective ``selenium`` counterpart class.
 .. autoclass:: behave_webdriver.Chrome
    :members:
 
-.. autoclass:: behave_webdriver.PhantomJS
-   :members:
-
 .. autoclass:: behave_webdriver.Firefox
    :members:
 
 .. autoclass:: behave_webdriver.Ie
    :members:
 
+.. autoclass:: behave_webdriver.Safari
+   :members:
+
+.. autoclass:: behave_webdriver.PhantomJS
+   :members:
+
 .. autoclass:: behave_webdriver.Edge
    :members:
 
 .. autoclass:: behave_webdriver.Opera
-   :members:
-
-.. autoclass:: behave_webdriver.Safari
    :members:
 
 .. autoclass:: behave_webdriver.BlackBerry

--- a/docs/browsers.rst
+++ b/docs/browsers.rst
@@ -15,6 +15,7 @@ This is not a repository or body of knowledge for all driver-related issues; jus
 Unless otherwise noted, we are referring to the latest stable release of Selenium and each respective browser and driver.
 Keep in mind, this documentation may not necessarily be up-to-date with very recent releases.
 
+
 Chrome (recommended)
 --------------------
 
@@ -28,10 +29,13 @@ While earlier versions should work fine and we are willing to support them, they
 
 
 
-Firefox (coming soon)
----------------------
+Firefox (beta)
+--------------
 
-We have preliminary support for Firefox available with tests at least mostly passing, FWIW. A preview will be available in v0.1.1
+Firefox is officially supported as of v0.1.1
+
+
+
 
 Known issues
 ^^^^^^^^^^^^
@@ -41,6 +45,31 @@ Known issues
 - clicking elements requires they are in the viewport (we compensate for this by scrolling to an element before any click)
 - moving to an element *with an offset* that is bigger than the viewport is not (yet) supported
 - slower than Chrome
+
+Workarounds/Shims
+^^^^^^^^^^^^^^^^^
+
+Shims and other workarounds for some known issues are implemented in the :py:`behave_webdriver.drivers.Firefox` class.
+
+See :doc:`api` for more details.
+
+
+Ie
+--
+
+We have some preliminary support for Internet Explorer. It is tested in our `appveyor CI build`_.
+
+.. _appveyor CI build: https://ci.appveyor.com/project/spyoungtech/behave-webdriver
+
+
+Safari
+------
+
+We have some preliminary support for Safari on OSX/Mac OS. It is tested as part of our `Travis CI build`_ (failures currently allowed).
+
+.. _Travis CI build: https://travis-ci.org/spyoungtech/behave-webdriver/
+
+
 
 PhantomJS
 ---------
@@ -72,11 +101,6 @@ Remote
 Remote is untested at this time.
 
 
-Ie
---
-
-Ie is untested at this time.
-
 
 Edge
 ----
@@ -88,10 +112,6 @@ Opera
 
 Opera is untested at this time.
 
-Safari
-------
-
-Safari is untested at this time.
 
 BlackBerry
 ----------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 alabaster==0.7.10
 Babel==2.5.3
-behave==1.2.5
+behave==1.2.6
 certifi==2018.1.18
 chardet==3.0.4
 colorama==0.3.9

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -15,14 +15,6 @@ Immediate and short term goals are some milestones that we are actively working 
 Ideally, these things have clearly defined requirements and some work in progress.
 
 
-Browser support (Firefox)
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Currently, Chrome is the recommended webdriver and is fully supported.
-A preview of firefox support is planned for V0.1.1
-
-We hope to have more refined support for firefox in a future version.
-
 
 Documentation; recipes & tutorials
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -59,11 +51,12 @@ are welcomed and very much appreciated.
 Browser support (others)
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Chrome and Firefox are in our forefront for browser support. We do however plan to test and provide at least best-effort
-support for all the webdrivers supported by selenium. At a minimum, we hope to get all browsers tested (but not necessarily in the CI build) and attempt to make
-note of differences and quirks.
+Chrome and Firefox are in our forefront for browser support. We do however plan to test and provide best-effort
+support for all the webdrivers supported by selenium.
 
-Having all browsers included in the CI build is not currently on the roadmap.
+We hope to get all browsers tested (but not necessarily passing) and attempt to make note of compatibility, behavior differences, and other browser-specific quirks.
+
+Would be nice to have more browsers tested in the CI builds as well.
 
 See :doc:`browsers` for more information.
 
@@ -123,6 +116,11 @@ improve the functionality of the library as a whole.
 
 Completed
 ---------
+
+Browser support (Firefox)
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Firefox is officially supported as of v0.1.1
 
 v0.1.0
 ^^^^^^


### PR DESCRIPTION
some general cleanup, doc updates, and some changes to fixture. Bumped behave requirements version for readthedocs to 1.2.6

Also removes fixtures from `__init__` so that behave<1.2.6 does not raise error.