### PR TITLE
pycharm BDD matcher workaround

### DIFF
--- a/behave_webdriver/steps/__init__.py
+++ b/behave_webdriver/steps/__init__.py
@@ -1,2 +1,3 @@
 from .actions import *
+from .actions_re import *
 from .expectations import *

--- a/behave_webdriver/steps/actions.py
+++ b/behave_webdriver/steps/actions.py
@@ -1,12 +1,16 @@
 import string
 from behave import *
+from behave_webdriver.transformers import matcher_mapping
 try:
     from urllib.parse import urljoin
 except ImportError:
     from urlparse import urljoin  # Python 2
 
 
-use_step_matcher('transform-parse')
+if 'transform-parse' not in matcher_mapping:
+    use_step_matcher('parse')
+else:
+    use_step_matcher('transform-parse')
 
 
 @when('I pause for {milliseconds:d}ms')
@@ -99,93 +103,6 @@ def move_to_element_offset(context, element, x_offset, y_offset):
 @when('I move to element "{element}"')
 def move_to_element(context, element):
     context.behave_driver.move_to_element(element)
-
-
-use_step_matcher('transform-re')
-
-
-@when('I close the last opened (tab|window)')
-def close_last_tab(context, _):
-    context.behave_driver.switch_to_window(context.behave_driver.last_opened_handle)
-    context.behave_driver.close()
-    context.behave_driver.switch_to_window(context.behave_driver.primary_handle)
-
-
-@when('I focus the last opened (tab|window)')
-def focus_last_tab(context, _):
-    context.behave_driver.switch_to_window(context.behave_driver.last_opened_handle)
-
-
-@when('I select the option with the (text|value|name) "([^"]*)?" for element "([^"]*)?"')
-def select_option_by(context, attr, attr_value, element):
-    attr_map = {'text': 'visible_text'}
-    attr = attr_map.get(attr, attr)
-    context.behave_driver.select_option(select_element=element,
-                                        by=attr,
-                                        by_arg=attr_value)
-
-
-@when('I accept the (alertbox|confirmbox|prompt)')
-def accept_alert(context, modal_type):
-    context.behave_driver.alert.accept()
-
-
-@when('I dismiss the (alertbox|confirmbox|prompt)')
-def dismiss_alert(context, modal_type):
-    context.behave_driver.alert.dismiss()
-
-
-@when('I enter "([^"]*)?" into the (alertbox|confirmbox|prompt)')
-def handle_prompt(context, text, modal_type):
-    context.behave_driver.alert.send_keys(text)
-
-
-@given('I have closed all but the first (window|tab)')
-def close_secondary_windows(context, window_or_tab):
-    if len(context.behave_driver.window_handles) > 1:
-        for handle in context.behave_driver.window_handles[1:]:
-            context.behave_driver.switch_to_window(handle)
-            context.behave_driver.close()
-    context.behave_driver.switch_to_window(context.behave_driver.primary_handle)
-
-
-@step('I open the url "([^"]*)?"')
-def open_url(context, url):
-    context.behave_driver.open_url(url)
-
-
-@step('I open the site "([^"]*)?"')
-def open_site(context, url):
-    base_url = getattr(context, 'base_url', 'http://localhost:8000')
-    destination = urljoin(base_url, url)
-    context.behave_driver.open_url(destination)
-
-
-@given('the base url is "([^"]*)?"')
-def set_base_url(context, url):
-    if url.endswith('/'):
-        url = url[:-1]
-    context.base_url = url
-
-
-@given('I pause for (\d+)*ms')
-def pause(context, milliseconds):
-    milliseconds = int(milliseconds)
-    context.behave_driver.pause(milliseconds)
-
-
-@given('I have a screen that is ([\d]+) by ([\d]+) pixels')
-def set_screen_size(context, x, y):
-    context.behave_driver.screen_size = (x, y)
-
-
-@given('I have a screen that is ([\d]+) pixels (broad|tall)')
-def set_screen_dimension(context, size, how):
-    size = int(size)
-    if how == 'tall':
-        context.behave_driver.screen_size = (None, size)
-    else:
-        context.behave_driver.screen_size = (size, None)
 
 
 use_step_matcher('parse')

--- a/behave_webdriver/steps/actions_re.py
+++ b/behave_webdriver/steps/actions_re.py
@@ -1,0 +1,96 @@
+from behave import *
+from behave_webdriver.transformers import matcher_mapping
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin  # Python 2
+
+
+if 'transform-parse' not in matcher_mapping:
+    use_step_matcher('re')
+else:
+    use_step_matcher('transform-re')
+
+
+@when('I close the last opened (tab|window)')
+def close_last_tab(context, _):
+    context.behave_driver.switch_to_window(context.behave_driver.last_opened_handle)
+    context.behave_driver.close()
+    context.behave_driver.switch_to_window(context.behave_driver.primary_handle)
+
+
+@when('I focus the last opened (tab|window)')
+def focus_last_tab(context, _):
+    context.behave_driver.switch_to_window(context.behave_driver.last_opened_handle)
+
+
+@when('I select the option with the (text|value|name) "([^"]*)?" for element "([^"]*)?"')
+def select_option_by(context, attr, attr_value, element):
+    attr_map = {'text': 'visible_text'}
+    attr = attr_map.get(attr, attr)
+    context.behave_driver.select_option(select_element=element,
+                                        by=attr,
+                                        by_arg=attr_value)
+
+
+@when('I accept the (alertbox|confirmbox|prompt)')
+def accept_alert(context, modal_type):
+    context.behave_driver.alert.accept()
+
+
+@when('I dismiss the (alertbox|confirmbox|prompt)')
+def dismiss_alert(context, modal_type):
+    context.behave_driver.alert.dismiss()
+
+
+@when('I enter "([^"]*)?" into the (alertbox|confirmbox|prompt)')
+def handle_prompt(context, text, modal_type):
+    context.behave_driver.alert.send_keys(text)
+
+
+@given('I have closed all but the first (window|tab)')
+def close_secondary_windows(context, window_or_tab):
+    if len(context.behave_driver.window_handles) > 1:
+        for handle in context.behave_driver.window_handles[1:]:
+            context.behave_driver.switch_to_window(handle)
+            context.behave_driver.close()
+    context.behave_driver.switch_to_window(context.behave_driver.primary_handle)
+
+
+@step('I open the url "([^"]*)?"')
+def open_url(context, url):
+    context.behave_driver.open_url(url)
+
+
+@step('I open the site "([^"]*)?"')
+def open_site(context, url):
+    base_url = getattr(context, 'base_url', 'http://localhost:8000')
+    destination = urljoin(base_url, url)
+    context.behave_driver.open_url(destination)
+
+
+@given('the base url is "([^"]*)?"')
+def set_base_url(context, url):
+    if url.endswith('/'):
+        url = url[:-1]
+    context.base_url = url
+
+
+@given('I pause for (\d+)*ms')
+def pause(context, milliseconds):
+    milliseconds = int(milliseconds)
+    context.behave_driver.pause(milliseconds)
+
+
+@given('I have a screen that is ([\d]+) by ([\d]+) pixels')
+def set_screen_size(context, x, y):
+    context.behave_driver.screen_size = (x, y)
+
+
+@given('I have a screen that is ([\d]+) pixels (broad|tall)')
+def set_screen_dimension(context, size, how):
+    size = int(size)
+    if how == 'tall':
+        context.behave_driver.screen_size = (None, size)
+    else:
+        context.behave_driver.screen_size = (size, None)

--- a/behave_webdriver/steps/expectations.py
+++ b/behave_webdriver/steps/expectations.py
@@ -1,11 +1,14 @@
 from behave import *
+from behave_webdriver.transformers import matcher_mapping
 try:
     from urllib.parse import urlparse
 except ImportError:
     from urlparse import urlparse
 
-
-use_step_matcher('transform-re')
+if 'transform-parse' not in matcher_mapping:
+    use_step_matcher('re')
+else:
+    use_step_matcher('transform-re')
 
 
 @given('the element "([^"]*)?" is( not)* visible')

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.rst', 'rt', encoding='utf8') as f:
 
 setup(
     name='behave-webdriver',
-    version='0.2.2',
+    version='0.3.0',
     url='https://github.com/spyoungtech/behave-webdriver/',
     license='MIT',
     author='Spencer Young',


### PR DESCRIPTION
Fixes step matching in PyCharm. Resolves #75 

There are two key problems solved here:

1. PyCharm won't recognize custom matchers (IE the transform matchers introduced in 0.2.0)
2. PyCharm will only match on the first matcher used in the file (e.g. first use of `use_step_matcher`)

To resolve (1) a conditional statement was added to 'fool' PyCharm by having a conditional statement (which will resolve False) to execute `use_step_matcher` with a non-custom matcher.

To resolve (2) regex actions steps were split to a separate file from parse matcher steps.